### PR TITLE
map literals, ::into, and ::merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Far too often when dealing with XML, Java objects, etc; I end up converting them
 
 (def xml-string "
 <responses>
-  <response status=\"okay\">
+  <response status=\"okay\" code=\"200\">
     <ident>1234</ident>
     <title lang=\"English\">Creativity fails me</title>
     <children>
@@ -55,7 +55,7 @@ Far too often when dealing with XML, Java objects, etc; I end up converting them
 
 (def xml-spec
   [#(zf/xml-> % :response)
-   {:status #(zf/xml1-> % (zf/attr :status))
+   {:into-edn/into #(some-> % (zf/xml1-> zip/node) :attrs)
     :ident  #(some-> %
                      (zf/xml1-> :ident zf/text)
                      (Long/parseLong))
@@ -73,6 +73,7 @@ Far too often when dealing with XML, Java objects, etc; I end up converting them
                            zip/xml-zip))
 ;; -->
 [{:status "okay",
+  :code "200",
   :ident 1234,
   :title "Creativity fails me",
   :title-lang "English",
@@ -118,5 +119,4 @@ With Maven:
 MIT
 http://opensource.org/licenses/MIT
 
-Copyright © 2013 Alan Busby
-
+Copyright © 2013 Alan Busby, 2018 Francois Rey

--- a/project.clj
+++ b/project.clj
@@ -3,16 +3,20 @@
   :url          "https://github.com/thebusby/into-edn"
   :license      {:name "MIT"
                  :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]]
   :profiles     {:1.2    {:dependencies [[org.clojure/clojure "1.2.0"]]}
                  :1.3    {:dependencies [[org.clojure/clojure "1.3.0"]]}
                  :1.4    {:dependencies [[org.clojure/clojure "1.4.0"]]}
-                 :1.6    {:dependencies [[org.clojure/clojure "1.6.0-master-SNAPSHOT"]]}
-                 :master {:dependencies [[org.clojure/clojure "1.6.0-master-SNAPSHOT"]]}}
-  :aliases      {"all" ["with-profile" "base:1.2:1.3:1.4:1.6:master"]}
-  :repositories {"sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"
+                 :1.5    {:dependencies [[org.clojure/clojure "1.5.1"]]}
+                 :1.6    {:dependencies [[org.clojure/clojure "1.6.0"]]}
+                 :1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}
+                 :1.8    {:dependencies [[org.clojure/clojure "1.8.0"]]}
+                 :1.10   {:dependencies [[org.clojure/clojure "1.10.0-alpha6"]]}
+                 :master {:dependencies [[org.clojure/clojure "1.10.0-master-SNAPSHOT"]]}}
+  :aliases      {"all" ["with-profile" "base:1.2:1.3:1.5:1.6:1.7:1.8:1.10:master"]}
+  :repositories {"sonatype" {:url "https://oss.sonatype.org/content/repositories/releases"
                              :snapshots false
                              :releases {:checksum :fail :update :always}}
-                 "sonatype-snapshots" {:url "http://oss.sonatype.org/content/repositories/snapshots"
+                 "sonatype-snapshots" {:url "https://oss.sonatype.org/content/repositories/snapshots"
                                        :snapshots true
                                        :releases {:checksum :fail :update :always}}})

--- a/project.clj
+++ b/project.clj
@@ -4,16 +4,14 @@
   :license      {:name "MIT"
                  :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.9.0"]]
-  :profiles     {:1.2    {:dependencies [[org.clojure/clojure "1.2.0"]]}
-                 :1.3    {:dependencies [[org.clojure/clojure "1.3.0"]]}
-                 :1.4    {:dependencies [[org.clojure/clojure "1.4.0"]]}
+  :profiles     {:1.4    {:dependencies [[org.clojure/clojure "1.4.0"]]}
                  :1.5    {:dependencies [[org.clojure/clojure "1.5.1"]]}
                  :1.6    {:dependencies [[org.clojure/clojure "1.6.0"]]}
                  :1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}
                  :1.8    {:dependencies [[org.clojure/clojure "1.8.0"]]}
                  :1.10   {:dependencies [[org.clojure/clojure "1.10.0-alpha6"]]}
                  :master {:dependencies [[org.clojure/clojure "1.10.0-master-SNAPSHOT"]]}}
-  :aliases      {"all" ["with-profile" "base:1.2:1.3:1.5:1.6:1.7:1.8:1.10:master"]}
+  :aliases      {"all" ["with-profile" "base:1.4:1.5:1.6:1.7:1.8:1.10:master"]}
   :repositories {"sonatype" {:url "https://oss.sonatype.org/content/repositories/releases"
                              :snapshots false
                              :releases {:checksum :fail :update :always}}

--- a/src/into_edn.clj
+++ b/src/into_edn.clj
@@ -2,19 +2,31 @@
   "A simple library to convert a Document/Object
    into EDN data via a spec.")
 
+(def ^{:private true} this-ns (namespace ::_))
+
+(defn actual-fn?
+  "Returns true is argument is a function and not a collection posing as one."
+  [f]
+  (and (fn? f) (not (coll? f))))
+
 (defprotocol IntoEdn
   (into-edn [spec target]
     "Produce EDN data via the provided spec and target.
 
-   A spec is defined by maps, vectors, and fns;
-   - An fn returns the result of (spec-fn target).
+   A spec is defined by maps, vectors, and functions;
+   - A function returns the result of (spec-fn target).
+     Note that keywords are not considered as functions
+     but as literals that remain in place.
    - vector [seq-fn], or [seq-fn elem-fn], returns a
      vector of the results of (seq-fn target) where
      seq-fn should return a seq. If an elem-fn is provided,
      it is applied to each element of the sequence before
      being returned.
    - map returns a map where each value in the map is
-     replaced.
+     replaced when it's a spec (function, map, or vector).
+     Two namespaced keywords, ::into and ::merge, allows the map to be
+     respectively pre-populated and post-merged with the replacement
+     of their values.
 
    Example:
    (def spec {:inc       inc
@@ -24,27 +36,61 @@
                           inc]
               :range-map [range
                           {:inc inc
-                           :dec dec}]})
-   (into-edn spec 3)"))
+                           :dec dec
+                           :untouched :literal}]
+              :into-map  {:into-edn/into {:a :overwritten-by-merge :d 3}
+                          :into-edn/merge #(into {}
+                                                 (for [v (range %)
+                                                       :let [k (-> v (+ 97) char
+                                                                   str keyword)]]
+                                                   [k v]))}})
+   (into-edn spec 3)
+   ;; => {:inc 4,
+   ;;     :range (0 1 2),
+   ;;     :range-vec [0 1 2],
+   ;;     :range-inc [1 2 3],
+   ;;     :range-map [{:inc 1,
+   ;;                  :dec -1,
+   ;;                  :untouched :literal}
+   ;;                 {:inc 2,
+   ;;                  :dec 0,
+   ;;                  :untouched :literal}
+   ;;                 {:inc 3,
+   ;;                  :dec 1,
+   ;;                  :untouched :literal}]
+   ;;     :into-map  {:a 0, :b 1, :c 2, :d 3}}"))
 
 (extend-protocol IntoEdn
 
+  java.lang.Object
+  (into-edn [spec target]
+    spec)
+
   clojure.lang.IFn
   (into-edn [spec target]
-    (spec target))
+    (if (actual-fn? spec)
+      (spec target)
+      spec))
 
   clojure.lang.APersistentVector
   (into-edn [[spec sub-spec] target]
     (let [elem-fn (if sub-spec
                     #(into-edn sub-spec %)
                     identity)]
-    (vec (map elem-fn (spec target)))))
+      (mapv elem-fn (spec target))))
 
   clojure.lang.APersistentMap
   (into-edn [spec target]
-    (persistent! (reduce (fn [agg [k v]]
-                           (assoc! agg k (into-edn v target)))
-                         (transient {})
-                         spec)))
+    (let [res (persistent! (reduce (fn [agg [k v]]
+                                     (if (= this-ns (namespace k))
+                                       agg
+                                       (assoc! agg k (into-edn v target))))
+                                   (transient (if-let [into-spec (::into spec)]
+                                                (into-edn into-spec target)
+                                                {}))
+                                   spec))]
+      (if-let [merge-spec (::merge spec)]
+        (merge res (into-edn merge-spec target))
+        res)))
 
   )

--- a/test/into_edn_test.clj
+++ b/test/into_edn_test.clj
@@ -12,8 +12,23 @@
                     :target (range 5)
                     :result [1 2 3 4 5]}
 
-                   {:title "The whole shebang"
+                   {:title "Just a map"
                     :spec {:inc inc
+                           :dec dec}
+                    :target 3
+                    :result {:inc 4, :dec 2}}
+
+                   {:title "Map with literals, into, and merge"
+                    :spec {:copied :literal
+                           :another-literal 1
+                           :into-edn/into #(get % :nested)
+                           :into-edn/merge {:a 1 :c 3 :e 5}}
+                    :target {:skipped :value :a :overwritten-value :nested {:b 2 :c 4 :d 4}}
+                    :result {:copied :literal :another-literal 1 :a 1 :b 2 :c 3 :d 4 :e 5}}
+
+                   {:title "More nested specs"
+                    :spec {:ident identity
+                           :inc inc
                            :dec dec
                            :range range
                            :range-vec [range]
@@ -26,14 +41,26 @@
                                      inc]
                            :chained-map {:inc inc
                                          :dec dec}
+                           :into-merge-map  {:into-edn/into {:a :overwritten-by-merge :d 3}
+                                             :into-edn/merge #(into {}
+                                                                    (for [v (range %)
+                                                                          :let [k (-> v (+ 97) char
+                                                                                      str keyword)]]
+                                                                      [k v]))}
                            :chained-vec [#(range (* % %))
                                          [range
-                                          inc]]
-                           :ident identity}
+                                          inc]]}
                     :target 3
-                    :result {:chained-map {:inc 4, :dec 2},
+                    :result {:ident 3,
                              :inc 4,
+                             :dec 2,
                              :range '(0 1 2),
+                             :range-vec [0 1 2],
+                             :range-inc [1 2 3],
+                             :range-map [{:inc 1, :dec -1} {:inc 2, :dec 0} {:inc 3, :dec 1}],
+                             :nil-vec [],
+                             :chained-map {:inc 4, :dec 2},
+                             :into-merge-map {:a 0, :b 1, :c 2, :d 3},
                              :chained-vec
                              [[]
                               [1]
@@ -43,13 +70,8 @@
                               [1 2 3 4 5]
                               [1 2 3 4 5 6]
                               [1 2 3 4 5 6 7]
-                              [1 2 3 4 5 6 7 8]],
-                             :nil-vec [],
-                             :dec 2,
-                             :range-vec [0 1 2],
-                             :range-map [{:inc 1, :dec -1} {:inc 2, :dec 0} {:inc 3, :dec 1}],
-                             :range-inc [1 2 3],
-                             :ident 3}}])
+                              [1 2 3 4 5 6 7 8]]
+                             }}])
 
 (deftest simple-test
 (doseq [{:keys [title spec target result]} simple-tests]


### PR DESCRIPTION
New features:
- Literals are now supported in maps, they are copied as-is.
- Two namespaced keywords, `::into` and `::merge`, allows the map to be
  respectively pre-populated and post-merged with the replacement
  of their values.

BREAKING CHANGE: keyword literals are no longer considered as functions specs, therefore
existing clients may break . Using an actual function instead is recommended,
e.g. use `#(get % :nested)` instead of `:nested`.  This PR requires a major version bump.